### PR TITLE
fix: trim whitespace in open answers and use strict equality

### DIFF
--- a/src/__tests__/answerSanitiser.test.ts
+++ b/src/__tests__/answerSanitiser.test.ts
@@ -6,4 +6,13 @@ describe("sanitiseAnswer", () => {
     expect(sanitiseAnswer("oxygen")).toBe("Oxygen");
     expect(sanitiseAnswer("He")).toBe("He");
   });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(sanitiseAnswer("  oxygen  ")).toBe("Oxygen");
+    expect(sanitiseAnswer("\toxygen\n")).toBe("Oxygen");
+  });
+
+  it("returns an empty string for whitespace-only input", () => {
+    expect(sanitiseAnswer("   ")).toBe("");
+  });
 });

--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -220,7 +220,7 @@ export default function Answer() {
     const givenAnswer = sanitiseAnswer(inputElement?.value);
     setPlayerAnswer(givenAnswer);
 
-    if (answer && givenAnswer == answer.name) {
+    if (answer && givenAnswer === answer.name) {
       setScore((prevScore: number) => prevScore + 1);
       setInput("");
       // Add guessed element symbol to HUD

--- a/src/utils/answerSanitiser.ts
+++ b/src/utils/answerSanitiser.ts
@@ -1,6 +1,8 @@
 export function sanitiseAnswer(answer: string) {
-  let baseAnswer = answer.toLowerCase();
-  let idxZeroChar = answer.slice(0, 1);
+  const trimmed = answer.trim();
+  if (!trimmed) return "";
+  let baseAnswer = trimmed.toLowerCase();
+  let idxZeroChar = trimmed.slice(0, 1);
   let capitalisedIdxZero = idxZeroChar.toUpperCase();
   return capitalisedIdxZero.concat(baseAnswer.slice(1));
 }


### PR DESCRIPTION
Part of wave-1 cleanup (audit item #13).