### PR TITLE
fix: wrap in-game navbar height in calc()

### DIFF
--- a/src/components/layout/InGameNavbar.tsx
+++ b/src/components/layout/InGameNavbar.tsx
@@ -82,7 +82,7 @@ export default function InGameNavbar({}: Props) {
       <nav
         className="fixed inset-x-0 top-0 w-full flex items-center justify-between px-4 py-2"
         style={{
-          height: "var(--site-navbar-height) + 20px",
+          height: "calc(var(--site-navbar-height) + 20px)",
           paddingLeft: "env(safe-area-inset-left)",
           paddingRight: "env(safe-area-inset-right)",
           zIndex: 3000,


### PR DESCRIPTION
Part of wave-1 cleanup (audit item #12).