### PR TITLE
fix: persist and restore guessedElements across refresh

### DIFF
--- a/src/__tests__/sessionPersistence.test.ts
+++ b/src/__tests__/sessionPersistence.test.ts
@@ -25,4 +25,38 @@ describe("session persistence writes fresh state", () => {
     );
     expect(saved.score).toBe(7);
   });
+
+  it("addGuessedElement persists the symbol in guessedElements", () => {
+    useGameStore.getState().addGuessedElement("H");
+
+    const saved = JSON.parse(
+      localStorage.getItem("atomology.session") || "{}"
+    );
+    expect(saved.guessedElements).toContain("H");
+  });
+});
+
+describe("session restore on load", () => {
+  it("restores guessedElements from a persisted session", async () => {
+    localStorage.clear();
+    localStorage.setItem(
+      "atomology.session",
+      JSON.stringify({
+        score: 3,
+        gameMode: "multi",
+        gameStarted: true,
+        elements: [],
+        answer: null,
+        answerElementName: null,
+        playerAnswer: "",
+        guessedElements: ["H", "He"],
+      })
+    );
+
+    jest.resetModules();
+    const { useGameStore: freshStore } = await import("../store/atomologyStore");
+
+    expect(freshStore.getState().guessedElements).toEqual(["H", "He"]);
+    expect(freshStore.getState().score).toBe(3);
+  });
 });

--- a/src/store/atomologyStore.ts
+++ b/src/store/atomologyStore.ts
@@ -91,6 +91,7 @@ export const useGameStore = create<GameState>((set, get) => {
         playerAnswer: s.playerAnswer,
         gameMode: s.gameMode,
         gameStarted: s.gameStarted,
+        guessedElements: s.guessedElements,
       };
       localStorage.setItem("atomology.session", JSON.stringify(toSave));
     } catch (err) {
@@ -111,7 +112,7 @@ export const useGameStore = create<GameState>((set, get) => {
     playerAnswer: (persisted?.playerAnswer as any) ?? null,
     answerElementName: (persisted?.answerElementName as any) ?? "",
     fetchTrigger: 0,
-    guessedElements: [],
+    guessedElements: (persisted?.guessedElements as any) ?? [],
     // Hangman state
     hangmanWord: null,
     hangmanGuessedLetters: [],


### PR DESCRIPTION
Wave-2 cleanup (audit item #3).